### PR TITLE
Do not print console logs when running on Java files

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           mkdir -p ~/.gradle
           printf "org.gradle.jvmargs=-Xmx3G -XX:+UseParallelGC\n" >> ~/.gradle/gradle.properties
+          printf "org.gradle.vfs.watch=false\n" >> ~/.gradle/gradle.properties
         shell: bash
 
       - uses: actions/setup-java@v3
@@ -86,6 +87,7 @@ jobs:
         run: |
           mkdir -p ~/.gradle
           printf "org.gradle.jvmargs=-Xmx3G -XX:+UseParallelGC\n" >> ~/.gradle/gradle.properties
+          printf "org.gradle.vfs.watch=false\n" >> ~/.gradle/gradle.properties
         shell: bash
 
       - uses: actions/setup-java@v3
@@ -157,6 +159,7 @@ jobs:
         run: |
           mkdir -p ~/.gradle
           printf "org.gradle.jvmargs=-Xmx3G -XX:+UseParallelGC\n" >> ~/.gradle/gradle.properties
+          printf "org.gradle.vfs.watch=false\n" >> ~/.gradle/gradle.properties
         shell: bash
 
       - uses: actions/setup-java@v3

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           mkdir -p ~/.gradle
           printf "org.gradle.jvmargs=-Xmx3G -XX:+UseParallelGC\n" >> ~/.gradle/gradle.properties
+          printf "org.gradle.vfs.watch=false\n" >> ~/.gradle/gradle.properties
         shell: bash
 
       - uses: actions/setup-java@v3

--- a/.github/workflows/diffuse.yml
+++ b/.github/workflows/diffuse.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           mkdir -p ~/.gradle
           printf "org.gradle.jvmargs=-Xmx3G -XX:+UseParallelGC\n" >> ~/.gradle/gradle.properties
+          printf "org.gradle.vfs.watch=false\n" >> ~/.gradle/gradle.properties
         shell: bash
 
       - uses: actions/setup-java@v3

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           mkdir -p ~/.gradle
           printf "org.gradle.jvmargs=-Xmx3G -XX:+UseParallelGC\n" >> ~/.gradle/gradle.properties
+          printf "org.gradle.vfs.watch=false\n" >> ~/.gradle/gradle.properties
         shell: bash
 
       - uses: actions/setup-java@v3

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           mkdir -p ~/.gradle
           printf "org.gradle.jvmargs=-Xmx3G -XX:+UseParallelGC\n" >> ~/.gradle/gradle.properties
+          printf "org.gradle.vfs.watch=false\n" >> ~/.gradle/gradle.properties
         shell: bash
 
       - uses: actions/setup-java@v3
@@ -61,6 +62,7 @@ jobs:
         run: |
           mkdir -p ~/.gradle
           printf "org.gradle.jvmargs=-Xmx3G -XX:+UseParallelGC\n" >> ~/.gradle/gradle.properties
+          printf "org.gradle.vfs.watch=false\n" >> ~/.gradle/gradle.properties
         shell: bash
 
       - uses: actions/setup-java@v3

--- a/ktlint-gradle-plugin/src/main/kotlin/io/github/usefulness/tasks/workers/KtlintWorker.kt
+++ b/ktlint-gradle-plugin/src/main/kotlin/io/github/usefulness/tasks/workers/KtlintWorker.kt
@@ -51,7 +51,7 @@ internal abstract class KtlintWorker : WorkAction<KtlintWorker.Parameters> {
             logger.debug("$name linting: $relativePath")
 
             if (file.extension !in supportedExtensions) {
-                logger.warn("$name ignoring non Kotlin file: $relativePath")
+                logger.info("$name ignoring non-Kotlin file: $relativePath")
                 return@forEach
             }
 


### PR DESCRIPTION
Not sure yet why they are popping up. For now, since they are harmless - disable the noisy console log