### PR TITLE
Fix AGP <9.0 compatibility

### DIFF
--- a/ktlint-gradle-plugin/src/main/kotlin/io/github/usefulness/pluginapplier/AndroidSourceSetApplier.kt
+++ b/ktlint-gradle-plugin/src/main/kotlin/io/github/usefulness/pluginapplier/AndroidSourceSetApplier.kt
@@ -1,5 +1,7 @@
 package io.github.usefulness.pluginapplier
 
+import com.android.build.api.AndroidPluginVersion
+import com.android.build.api.dsl.AndroidSourceDirectorySet
 import com.android.build.api.dsl.AndroidSourceSet
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.variant.AndroidComponentsExtension
@@ -9,6 +11,7 @@ import io.github.usefulness.SourceSetApplier
 import io.github.usefulness.id
 import org.gradle.api.Project
 import org.gradle.api.file.FileTree
+import java.io.File
 
 internal object AndroidSourceSetApplier : SourceSetApplier {
 
@@ -18,14 +21,16 @@ internal object AndroidSourceSetApplier : SourceSetApplier {
             commonExtension as CommonExtension
             commonExtension.sourceSets.configureEach { sourceSet ->
                 val id = sourceSet.name.id
-                action(id, getKotlinFiles(project, sourceSet))
+                action(id, getKotlinFiles(project, sourceSet, android.pluginVersion))
             }
         }
     }
 
-    private fun getKotlinFiles(project: Project, sourceSet: AndroidSourceSet): FileTree {
-        val javaSources = sourceSet.java.directories
-        val kotlinSources = sourceSet.kotlin.directories
+    private fun getKotlinFiles(project: Project, sourceSet: AndroidSourceSet, appliedAgpVersion: AndroidPluginVersion): FileTree {
+        val fixedAgpVersion = AndroidPluginVersion(9, 0)
+
+        val javaSources = if (appliedAgpVersion >= fixedAgpVersion) sourceSet.java.directories else sourceSet.java.srcDirsInterop
+        val kotlinSources = if (appliedAgpVersion >= fixedAgpVersion) sourceSet.kotlin.directories else sourceSet.kotlin.srcDirsInterop
 
         val emptyFileTree = project.files().asFileTree
 
@@ -34,3 +39,8 @@ internal object AndroidSourceSetApplier : SourceSetApplier {
             .fold(emptyFileTree) { merged, tree -> merged + tree }
     }
 }
+
+@Suppress("UNCHECKED_CAST")
+private val AndroidSourceDirectorySet.srcDirsInterop
+    get() = (javaClass.getMethod("getSrcDirs").invoke(this) as Set<File>)
+        .map { it.path }


### PR DESCRIPTION
`directories` returns literal `"provider(?)"` string...